### PR TITLE
fix regression test

### DIFF
--- a/orchestrator/src/chain.js
+++ b/orchestrator/src/chain.js
@@ -263,5 +263,6 @@ module.exports = {
   chainNodeInfo,
   getMetrics,
   initNonce,
-  canSendTransactions
+  canSendTransactions,
+  getPeerNumber
 };


### PR DESCRIPTION
Missing export function used in test. regression introduce [here](https://github.com/luguslabs/archipel/commit/44a833162510f079684b2ffec539cd420f96db4a#diff-64889e38e7a719e742997618ba52e56cL231)

 error was then :

  ● Get peers number

   TypeError: getPeerNumber is not a function

     66 |  
     67 | test('Get peers number', async () => {
   > 68 |   const peers = await getPeerNumber(api);
        |                       ^
     69 |   expect(peers).toBe(2);
     70 | });
     71 |  

     at Object.<anonymous> (src/__tests__/chain-test.js:68:23)


See during development and test for  "add centry node" issue