### PR TITLE
deploy ui frontend on IPFS resolved at archipel.eth

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -49,6 +49,25 @@ docker run -it -p 8080:80 luguslabs/archipel-ui
 ```
 * After run you can access the Archipel UI at http://localhost:8080.
 
+## Publish on IPFS
+
+- connect to your dappnode wifi ( to target IPFS )
+- launch :
+```bash
+npm run ipfs-publish
+```
+
+Expected result :
+
+```bash
+To point an .eth domain to this website, use this hash as value:
+
+   QmZMUfKEsXAR8goa8LnJDDSkGqPpLaNkzdRd6k4d357Fed
+
+To preview you website immediately go to:
+
+   http://my.ipfs.dnp.dappnode.eth:8080/ipfs/QmZMUfKEsXAR8goa8LnJDDSkGqPpLaNkzdRd6k4d357Fed
+```
 
 ## Configuration
 

--- a/ui/ipfsDwebUploader.js
+++ b/ui/ipfsDwebUploader.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const IPFS = require("ipfs");
+const ipfsClient = require("ipfs-http-client");
+const ipfsProvider = "http://ipfs.dappnode:5001";
+const ipfsGateway = "http://my.ipfs.dnp.dappnode.eth:8080";
+const ipfs = ipfsClient(ipfsProvider);
+const { globSource } = IPFS;
+
+const args = process.argv.slice(2);
+const path = args[0];
+
+const uploadWebsite = async () => {
+  let results = [];
+  for await (const file of ipfs.add(
+    globSource(path, { recursive: true, wrapWithDirectory: true })
+  )) {
+    results.push(file);
+    console.log(file);
+  }
+  const dwebHash = results[results.length - 1].cid;
+  console.log("\n\n\n");
+  console.log(
+    `To point an .eth domain to this website, use this hash as value:`
+  );
+  console.log("\x1b[36m%s\x1b[0m", `\n   ${dwebHash}\n`);
+  console.log(`To preview you website immediately go to:`);
+  console.log("\x1b[36m%s\x1b[0m", `\n   ${ipfsGateway}/ipfs/${dwebHash}\n`);
+  return;
+};
+
+uploadWebsite();

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,7 +26,9 @@
     "eslint-plugin-only-warn": "^1.0.1",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
-    "gh-pages": "^2.1.1"
+    "gh-pages": "^2.1.1",
+    "ipfs": "^0.41.2",
+    "ipfs-http-client": "^42.0.0"
   },
   "scripts": {
     "start": "PORT=8000 react-scripts start",
@@ -37,7 +39,8 @@
     "lint:ci": "eslint src/** --max-warnings=0",
     "lint:fix": "eslint --fix src/**",
     "predeploy": "yarn build",
-    "deploy": "gh-pages -d build -m '[ci skip] Updates'"
+    "deploy": "gh-pages -d build -m '[ci skip] Updates'",
+    "ipfs-publish": "cp -f ./src/config/production.json ./src/config/production.sav && cp -f ./src/config/test.json ./src/config/production.json && react-scripts build && rm build/static/js/*.map && rm build/static/css/*.map && node ./ipfsDwebUploader build/ && cp -f ./src/config/production.sav ./src/config/production.json"
   },
   "eslintConfig": {
     "extends": [
@@ -67,7 +70,7 @@
       "last 1 safari version"
     ]
   },
-  "homepage": "/",
+  "homepage": "./",
   "bugs": {
     "url": "https://github.com/luguslabs/archipel.git/issues"
   },


### PR DESCRIPTION
close #133 

To point an .eth domain to this website, use this hash as value:

   QmZMUfKEsXAR8goa8LnJDDSkGqPpLaNkzdRd6k4d357Fed

To preview you website immediately go to:

   http://my.ipfs.dnp.dappnode.eth:8080/ipfs/QmZMUfKEsXAR8goa8LnJDDSkGqPpLaNkzdRd6k4d357Fed


http://archipel.eth resolved also